### PR TITLE
Introduction image in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ PyTurboGrid
    :alt: TurboGrid
    :width: 600 
 
-A Python wrapper for `Ansys TurboGrid`_ to generate high quality turbomachinery meshes.
+A Python wrapper for `Ansys TurboGrid`_ software to generate high quality turbomachinery meshes.
 
 |intro| 
 


### PR DESCRIPTION
This PR adds an image of a mesh generated in TurboGrid as an introduction image in the Readme page. The shape of the image is square for now. The image can be updated any time without touching Readme file to change the shape of the image or so.