### PR TITLE
Make type hints compatible with python 3.8 and 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-turbogrid-core"
 version = "0.2.dev0"
 description = "A python wrapper for Ansys TurboGrid"
 readme = "README.rst"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.8,<4"
 license = {file = "LICENSE"}
 
 authors = [

--- a/src/ansys/turbogrid/core/launcher/launcher.py
+++ b/src/ansys/turbogrid/core/launcher/launcher.py
@@ -5,6 +5,7 @@ from enum import Enum
 import os
 from pathlib import Path
 import platform
+from typing import Optional
 
 from ansys.turbogrid.api import pyturbogrid_core
 
@@ -118,7 +119,7 @@ def launch_turbogrid(
     log_level: pyturbogrid_core.PyTurboGrid.TurboGridLogLevel = pyturbogrid_core.PyTurboGrid.TurboGridLogLevel.INFO,
     additional_args_str: str = None,
     additional_kw_args: dict = None,
-    port: int | None = None,
+    port: Optional[int] = None,
     **kwargs,
 ) -> pyturbogrid_core.PyTurboGrid:
     """Launch TurboGrid locally in server mode.


### PR DESCRIPTION
This pull request allow this repo to run with python 3.8 and 3.9, in addition to python 3.10 and 3.11.