### PR TITLE
Import fixes for new path and launcher

### DIFF
--- a/examples/mesh_statistics_report.py
+++ b/examples/mesh_statistics_report.py
@@ -32,7 +32,7 @@ from collections import OrderedDict
 from datetime import date
 import os.path as ospath
 
-from ansys.turbogrid.api.cfx.ccl_object_db import CCLObjectDB
+from ansys.turbogrid.api.CCL.ccl_object_db import CCLObjectDB
 from jinja2 import Environment, FileSystemLoader
 
 from ansys.turbogrid.core.launcher.launcher import get_turbogrid_exe_path, launch_turbogrid

--- a/src/ansys/turbogrid/core/__init__.py
+++ b/src/ansys/turbogrid/core/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 ANSYS, Inc. All rights reserved
 """PyTurboGrid is a Python wrapper for Ansys TurboGrid."""
 
+from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
+
 try:
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:  # pragma: no cover


### PR DESCRIPTION
1. Fix import for new library path in ansys-api-turbogrid.
2. Allow more convenient access to the launch_turbogrid function.