### PR TITLE
Acohen/unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           pip install pytest-cov
           pip install fabric
           pip install .
-          echo ${{ secrets.CONTAINER_ACCESS_KEY }} > tg_container_key
+          echo -e ${{ secrets.CONTAINER_ACCESS_KEY }} > tg_container_key
           python3 -u -m pytest -vs --execution_mode=CONTAINERIZED --license_file=${{ env.ANSYSLMD_LICENSE_FILE }} --image_name=ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241 --cfxtg_command_name=cfxtgpynoviewer --cfx_version=241 --ssh_key_filename=./tg_container_key
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
           docker network ls
           docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241    
 
+      - name: Create Key
+        uses: mobiledevops/secret-to-file-action@v1
+        with:
+          base64-encoded-secret: ${{ secrets.CONTAINER_ACCESS_KEY }}
+          filename: "tg_container_key"
+          working-directory: "." 
+
       - name: Spin Up TurboGrid Container
         run: |
           docker image ls
@@ -92,7 +99,6 @@ jobs:
           pip install pytest-cov
           pip install fabric
           pip install .
-          echo -e ${{ secrets.CONTAINER_ACCESS_KEY }} > tg_container_key
           python3 -u -m pytest -vs --execution_mode=CONTAINERIZED --license_file=${{ env.ANSYSLMD_LICENSE_FILE }} --image_name=ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241 --cfxtg_command_name=cfxtgpynoviewer --cfx_version=241 --ssh_key_filename=./tg_container_key
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: ansys/actions/build-wheelhouse@v5
@@ -73,6 +73,17 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+
+
+    name: "Tests for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
+    runs-on: ${{ matrix.os }}
+    needs: [code-style]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Pull TurboGrid Linux Image
         run: |
           docker network ls
-          docker pull ghcr.io/ansys/ansys-api-turbogrid/tg_reduced:241    
+          docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241    
 
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.
   build-library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: ansys/actions/build-wheelhouse@v5
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          library-namespace: ${{ env.LIBRARY_NAMESPACE }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GHCRLOGINTOKEN }}
+
+      - name: Pull TurboGrid Linux Image
+        run: |
+          docker network ls
+          docker pull ghcr.io/ansys/ansys-api-turbogrid/tg_reduced:$241    
 
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.
   build-library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: ansys/actions/build-wheelhouse@v5
@@ -76,15 +76,20 @@ jobs:
 
 
   smoke-tests:
-    name: "Tests for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
+    name: "Build wheelhouse and Test for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
-    needs: [wheelhouse, code-style]
+    needs: [code-style]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
+      - uses: ansys/actions/build-wheelhouse@v5
+        with:
+          library-name: ${{ env.LIBRARY_NAME }}
+          operating-system: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}        
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -117,7 +122,7 @@ jobs:
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.
   build-library:
     name: Build library
-    needs: [smoke-tests, docs-build]
+    needs: [wheelhouse, smoke-tests, docs-build]
     runs-on: ubuntu-latest
     steps:
       - name: "Build library source and wheel artifacts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: ansys/actions/build-wheelhouse@v5
@@ -82,7 +82,7 @@ jobs:
       - name: Pull TurboGrid Linux Image
         run: |
           docker network ls
-          docker pull ghcr.io/ansys/ansys-api-turbogrid/tg_reduced:$241    
+          docker pull ghcr.io/ansys/ansys-api-turbogrid/tg_reduced:241    
 
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.
   build-library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
   
-  smoke-tests:
+  wheelhouse:
     name: "Build wheelhouse for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
     needs: [code-style]
@@ -75,9 +75,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 
+  smoke-tests:
     name: "Tests for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
-    needs: [code-style]
+    needs: [wheelhouse, code-style]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 # Environment Variables
 env:
+  ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
   MAIN_PYTHON_VERSION: '3.10' # We need 3.9 for building sphinx
   LIBRARY_NAME: 'ansys-turbogrid-core' # The repo name
   LIBRARY_NAMESPACE: 'ansys.turbogrid.core'
@@ -83,6 +84,16 @@ jobs:
         run: |
           docker network ls
           docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241    
+
+      - name: Spin Up TurboGrid Container
+        run: |
+          docker image ls
+          pip install pytest
+          pip install pytest-cov
+          pip install fabric
+          pip install .
+          python3 -u -m pytest -vs --execution_mode=CONTAINERIZED --license_file=${{ env.ANSYSLMD_LICENSE_FILE }} --image_name=ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241 --cfxtg_command_name=cfxtgpynoviewer --cfx_version=241 --ssh_key_filename=./image_files/tg_container_key
+
 
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.
   build-library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,8 @@ jobs:
           pip install pytest-cov
           pip install fabric
           pip install .
-          python3 -u -m pytest -vs --execution_mode=CONTAINERIZED --license_file=${{ env.ANSYSLMD_LICENSE_FILE }} --image_name=ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241 --cfxtg_command_name=cfxtgpynoviewer --cfx_version=241 --ssh_key_filename=./image_files/tg_container_key
+          echo ${{ secrets.CONTAINER_ACCESS_KEY }} > tg_container_key
+          python3 -u -m pytest -vs --execution_mode=CONTAINERIZED --license_file=${{ env.ANSYSLMD_LICENSE_FILE }} --image_name=ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced:241 --cfxtg_command_name=cfxtgpynoviewer --cfx_version=241 --ssh_key_filename=./tg_container_key
 
 
 # The build job is responsible for creating the build artifact and uploading it to PYPI using twine.

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,8 @@ PyClientOutgoing.txt
 SCHEDULER SEQUENCE.dat
 SUPER PROFILER OVER 50ms.dat
 SUPER PROFILER.dat
-
+PyClientConsole*.txt
+PyClientOutgoing*.txt
+TurboGridLog*.txt
 # VSCode settings
 .vscode

--- a/src/ansys/turbogrid/core/__init__.py
+++ b/src/ansys/turbogrid/core/__init__.py
@@ -10,4 +10,8 @@ except ModuleNotFoundError:  # pragma: no cover
 
 # Read from the pyproject.toml
 # major, minor, patch
-__version__ = importlib_metadata.version("ansys-turbogrid-core")
+__version__ = "0.0.0"
+try:
+    __version__ = importlib_metadata.version("ansys-turbogrid-core")
+except importlib_metadata.PackageNotFoundError:
+    pass

--- a/tests/DeployTGContainer.py
+++ b/tests/DeployTGContainer.py
@@ -1,0 +1,140 @@
+import platform
+import subprocess
+import time
+
+
+class deployed_tg_container:
+    image_name: str
+    socket_port: int
+    ftp_port: int
+    cfxtg_command: str
+    license_server: str
+    container_name: str
+    is_linux: bool
+    prepend_command: str
+    keep_stopped_container: bool
+
+    def __init__(
+        self,
+        image_name: str,
+        socket_port: int,
+        ftp_port: int,
+        cfxtg_command: str,
+        license_server: str,
+        container_name: str = "TG_CONTAINER",
+        keep_stopped_container=False,
+        additional_env_vars={},
+    ):
+        self.image_name = image_name
+        self.socket_port = socket_port
+        self.ftp_port = ftp_port
+        self.cfxtg_command = cfxtg_command
+        self.license_server = license_server
+        self.container_name = container_name
+        self.keep_stopped_container = keep_stopped_container
+        self.is_linux = platform.system() == "Linux"
+        additional_env_string: str = ""
+        for key, val in additional_env_vars.items():
+            additional_env_string += f" -e {key}={val} "
+        print("\n")
+        print(f"######### Launching Container #########")
+        print(f"       tg_container_name = {self.container_name}")
+        print(f"       tg_image_name = {self.image_name}")
+        print(f"       socketPort = {self.socket_port}")
+        print(f"       ftpPort = {self.ftp_port}")
+        print(f"       cfxtg_command = {self.cfxtg_command}")
+        print(f"       license_server = {self.license_server}")
+        print(f"       platform = {platform.system()}")
+        print(f"       is_linux = {self.is_linux}")
+        print(f"       additional_env_vars = {additional_env_vars}")
+        print(f"       additional_env_string = {additional_env_string}")
+        print("\n")
+
+        # subprocess.run(
+        #     "env"
+        #     if self.is_linux
+        #     else '"C:/Program Files/PowerShell/7/pwsh.exe" -Command gci env:',
+        #     shell=True,
+        # )
+        self.prepend_command = (
+            "sudo" if self.is_linux else '"C:/Program Files/PowerShell/7/pwsh.exe" -Command'
+        )
+        logical_and = "&&" if self.is_linux else "^&^&"
+        print("######### Spin up docker image #########")
+        print(f"Remove any existing containers: {self.container_name}")
+        subprocess.run(
+            f"{self.prepend_command} docker container rm -fv {self.container_name}", shell=True
+        )
+        docker_command = (
+            f"{self.prepend_command} docker run --name {self.container_name} "
+            f"-e ANSYSLMD_LICENSE_FILE={self.license_server} {additional_env_string}"
+            f"-p {self.socket_port}:{self.socket_port} "
+            f"-p {self.ftp_port}:{self.ftp_port} "
+            f"-d {self.image_name} /bin/bash -c '/usr/local/bin/start_sshd.sh {self.ftp_port} {logical_and} {self.cfxtg_command}'"
+        )
+        print(f"docker_command: {docker_command}")
+        print(f"start tg...")
+        subprocess.run(f"{docker_command}", shell=True)
+        print(f"sleep...")
+        # Wait 2 seconds for the container to actually be responsive
+        time.sleep(2)
+        print(f"TG container ready")
+
+    def __del__(self):
+        print("\n######### Dispose of container #########")
+        subprocess.run(
+            f"{self.prepend_command} docker container stop {self.container_name}", shell=True
+        )
+        if self.keep_stopped_container == False:
+            subprocess.run(
+                f"{self.prepend_command} docker container rm -fv {self.container_name}", shell=True
+            )
+        print("######### All done #########")
+
+
+class remote_tg_instance:
+    socket_port: int
+    cfxtg_command: str
+    # license_server: str
+    is_linux: bool
+    tg_proc: subprocess.Popen
+
+    def __init__(
+        self,
+        socket_port: int,
+        cfxtg_command_noargs: str,
+        # license_server: str,
+    ):
+        self.socket_port = socket_port
+        self.cfxtg_command = f'"{cfxtg_command_noargs}" -py -control-port {self.socket_port}'
+        # self.license_server = license_server
+        self.is_linux = platform.system() == "Linux"
+        print("\n")
+        print(f"######### Launching Remote Instance #########")
+        print(f"       socketPort = {self.socket_port}")
+        print(f"       cfxtg_command = {self.cfxtg_command}")
+        # print(f"       license_server = {self.license_server}")
+        print(f"       platform = {platform.system()}")
+        print(f"       is_linux = {self.is_linux}")
+        print("\n")
+        subprocess.run(
+            "env"
+            if self.is_linux
+            else '"C:/Program Files/PowerShell/7/pwsh.exe" -Command gci env:',
+            shell=True,
+        )
+        print("######### Spin up remote process #########")
+        self.tg_proc = subprocess.Popen(
+            f"{self.cfxtg_command}",
+            shell=True,
+        )
+        print(f"pid: {self.tg_proc.pid}")
+        print(f"sleep...")
+        # Wait 2 seconds for the container to actually be responsive
+        time.sleep(2)
+        print(f"TG instance ready")
+
+    def __del__(self):
+        print("\n######### Dispose of process #########")
+        self.tg_proc.kill()
+        print("######### All done #########")

--- a/tests/DeployTGContainer.py
+++ b/tests/DeployTGContainer.py
@@ -82,6 +82,8 @@ class deployed_tg_container:
         print(f"TG container ready")
 
     def __del__(self):
+        print("\n######### Container Console Output #########")
+        subprocess.run(f"{self.prepend_command} docker logs {self.container_name}", shell=True)
         print("\n######### Dispose of container #########")
         subprocess.run(
             f"{self.prepend_command} docker container stop {self.container_name}", shell=True

--- a/tests/DeployTGContainer.py
+++ b/tests/DeployTGContainer.py
@@ -70,7 +70,8 @@ class deployed_tg_container:
             f"-e ANSYSLMD_LICENSE_FILE={self.license_server} {additional_env_string}"
             f"-p {self.socket_port}:{self.socket_port} "
             f"-p {self.ftp_port}:{self.ftp_port} "
-            f"-d {self.image_name} /bin/bash -c '/usr/local/bin/start_sshd.sh {self.ftp_port} {logical_and} {self.cfxtg_command}'"
+            f"-d {self.image_name} /bin/bash -c '/usr/local/bin/start_sshd.sh "
+            f" {self.ftp_port} {logical_and} {self.cfxtg_command}'"
         )
         print(f"docker_command: {docker_command}")
         print(f"start tg...")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,56 +1,4 @@
-# # Copyright (c) 2023 ANSYS, Inc. All rights reserved
-# import os
-# import sys
-
-# import pytest
-
-# pyturbogrid_root = os.getenv("PYTURBOGRID_ROOT")
-# if pyturbogrid_root:
-#     sys.path.append(f"{pyturbogrid_root}/src")
-# else:
-#     sys.path.append("./src")
-
-# # Note, internal ANSYS developers will have this available.
-# # External developers will need to have the most up-to-date ansys-turbogrid-api
-# # package installed in order to continue below.
-# pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
-# if pyturbogrid_api_root:
-#     sys.path.append(f"{pyturbogrid_api_root}/src")
-
-
-# from ansys.turbogrid.api import pyturbogrid_core
-
-
-# pytest.socket_port = 5000
-
-
-# # Fixtures are set-up methods. The method is passed as an argument to the test method and will be
-# # run before the method definition.
-# @pytest.fixture
-# def pyturbogrid() -> pyturbogrid_core.PyTurboGrid:
-#     pytest.socket_port += 1
-#     is_debug = os.getenv("PYTURBOGRID_DEBUG")
-#     if is_debug == "1":
-#         additional_args = "-debug"
-#     else:
-#         additional_args = None
-
-#     tg_local_root = os.getenv("PYTURBOGRID_TURBOGRID_LOCAL_ROOT")
-#     if tg_local_root:
-#         additional_kw_args = {"local-root": tg_local_root}
-#     else:
-#         additional_kw_args = None
-
-#     pyturbogrid = launch_turbogrid(
-#         additional_args_str=additional_args,
-#         additional_kw_args=additional_kw_args,
-#         port=pytest.socket_port,
-#     )
-#     print("Success")
-#     return pyturbogrid
-
-
-# Copyright (c) 2023 ANSYS, Inc. All rights reserved
+# Copyright (c) 2024 ANSYS, Inc. All rights reserved
 import ast
 from enum import IntEnum
 import os
@@ -65,7 +13,6 @@ import pytest
 
 from DeployTGContainer import deployed_tg_container, remote_tg_instance
 
-
 pyturbogrid_root = os.getenv("PYTURBOGRID_ROOT")
 if pyturbogrid_root:
     sys.path.append(f"{pyturbogrid_root}/src")
@@ -78,10 +25,9 @@ if pyturbogrid_api_root:
 else:
     raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
 
-from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
-
-
 from ansys.turbogrid.api import pyturbogrid_core
+
+# from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
 
 
 class TestExecutionMode(IntEnum):
@@ -130,19 +76,22 @@ def pytest_addoption(parser):
     parser.addoption(
         "--ssh_key_filename",
         action="store",
-        help="The location of the ssh key for connection to the TurboGrid container. Used when --execution-mode==CONTAINERIZED",
+        help="The location of the ssh key for connection to the TurboGrid container. "
+        "Used when --execution-mode==CONTAINERIZED",
     )
     parser.addoption(
         "--container_env_dict",
         action="store",
         default="{}",
-        help="A dictionary for additional environment variables to pass to the container. Used when --execution-mode==CONTAINERIZED",
+        help="A dictionary for additional environment variables to pass to the container. "
+        "Used when --execution-mode==CONTAINERIZED",
     )
     parser.addoption(
         "--keep_stopped_containers",
         action="store_true",
         default=False,
-        help="Whether or not to leave the stopped containers around without removing them. Used when --execution-mode==CONTAINERIZED",
+        help="Whether or not to leave the stopped containers around without removing them. "
+        "Used when --execution-mode==CONTAINERIZED",
     )
     parser.addoption(
         "--remote_command",
@@ -222,7 +171,8 @@ def get_enum_value_from_env(
         enum_value = enum_type[enum_value]
     except KeyError:
         raise RuntimeError(
-            f"Environment variable {env_var_name} was set to an invalid value '{enum_value}'. Valid values include {valid_values_str}."
+            f"Environment variable {env_var_name} was set to an invalid value '{enum_value}'. "
+            f"Valid values include {valid_values_str}."
         )
     return enum_value
 
@@ -236,7 +186,8 @@ def get_tg_container(pytestconfig, socket_port: int) -> deployed_tg_container:
     # The path to cfxtg_command is standardized by the container, so just replace the command name.
     # This allows image developers to write custom cfxtg commands.
     cfxtg_command: str = pytestconfig.getoption("cfxtg_command_name")
-    cfxtg_command = f"./v{pytestconfig.getoption('cfx_version')}/TurboGrid/bin/{cfxtg_command} -py -control-port {socket_port}"
+    cfxtg_command = f"./v{pytestconfig.getoption('cfx_version')}/TurboGrid/bin/{cfxtg_command} "
+    f"-py -control-port {socket_port}"
 
     license_server: str = pytestconfig.getoption("license_file")
     pytest.ftp_port = get_open_port()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,70 @@
-# Copyright (c) 2023 ANSYS, Inc. All rights reserved
-import os
-import sys
+# # Copyright (c) 2023 ANSYS, Inc. All rights reserved
+# import os
+# import sys
 
+# import pytest
+
+# pyturbogrid_root = os.getenv("PYTURBOGRID_ROOT")
+# if pyturbogrid_root:
+#     sys.path.append(f"{pyturbogrid_root}/src")
+# else:
+#     sys.path.append("./src")
+
+# # Note, internal ANSYS developers will have this available.
+# # External developers will need to have the most up-to-date ansys-turbogrid-api
+# # package installed in order to continue below.
+# pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
+# if pyturbogrid_api_root:
+#     sys.path.append(f"{pyturbogrid_api_root}/src")
+
+
+# from ansys.turbogrid.api import pyturbogrid_core
+
+
+# pytest.socket_port = 5000
+
+
+# # Fixtures are set-up methods. The method is passed as an argument to the test method and will be
+# # run before the method definition.
+# @pytest.fixture
+# def pyturbogrid() -> pyturbogrid_core.PyTurboGrid:
+#     pytest.socket_port += 1
+#     is_debug = os.getenv("PYTURBOGRID_DEBUG")
+#     if is_debug == "1":
+#         additional_args = "-debug"
+#     else:
+#         additional_args = None
+
+#     tg_local_root = os.getenv("PYTURBOGRID_TURBOGRID_LOCAL_ROOT")
+#     if tg_local_root:
+#         additional_kw_args = {"local-root": tg_local_root}
+#     else:
+#         additional_kw_args = None
+
+#     pyturbogrid = launch_turbogrid(
+#         additional_args_str=additional_args,
+#         additional_kw_args=additional_kw_args,
+#         port=pytest.socket_port,
+#     )
+#     print("Success")
+#     return pyturbogrid
+
+
+# Copyright (c) 2023 ANSYS, Inc. All rights reserved
+import ast
+from enum import IntEnum
+import os
+import random
+import socket
+import sys
+import time
+from typing import Optional
+
+from fabric import Connection
 import pytest
+
+from DeployTGContainer import deployed_tg_container, remote_tg_instance
+
 
 pyturbogrid_root = os.getenv("PYTURBOGRID_ROOT")
 if pyturbogrid_root:
@@ -10,42 +72,332 @@ if pyturbogrid_root:
 else:
     sys.path.append("./src")
 
-# Note, internal ANSYS developers will have this available.
-# External developers will need to have the most up-to-date ansys-turbogrid-api
-# package installed in order to continue below.
 pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
 if pyturbogrid_api_root:
     sys.path.append(f"{pyturbogrid_api_root}/src")
+else:
+    raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
+
+from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
 
 
 from ansys.turbogrid.api import pyturbogrid_core
 
-from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
 
-pytest.socket_port = 5000
+class TestExecutionMode(IntEnum):
+    __test__ = False
+    DIRECT = 0
+    REMOTE = 1
+    CONTAINERIZED = 2
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--cfx_version",
+        action="store",
+        default="232",
+        help="Version of the base product to test",
+    )
+    parser.addoption(
+        "--execution_mode",
+        action="store",
+        default="DIRECT",
+        help="execution_mode can be either DIRECT, REMOTE or CONTAINERIZED",
+        choices=("DIRECT", "REMOTE", "CONTAINERIZED"),
+    )
+    parser.addoption(
+        "--license_file",
+        action="store",
+        help="License file is required when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--image_name",
+        action="store",
+        help="The docker image name is required when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--container_name",
+        action="store",
+        default="TGCONTAINER",
+        help="The docker container name is required when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--cfxtg_command_name",
+        action="store",
+        default="cfxtg",
+        help="The optional command name to execute within the container when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--ssh_key_filename",
+        action="store",
+        help="The location of the ssh key for connection to the TurboGrid container. Used when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--container_env_dict",
+        action="store",
+        default="{}",
+        help="A dictionary for additional environment variables to pass to the container. Used when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--keep_stopped_containers",
+        action="store_true",
+        default=False,
+        help="Whether or not to leave the stopped containers around without removing them. Used when --execution-mode==CONTAINERIZED",
+    )
+    parser.addoption(
+        "--remote_command",
+        action="store",
+        help="A remote command is required when --execution-mode==REMOTE",
+    )
+    parser.addoption(
+        "--local_cfxtg_path",
+        action="store",
+        help="The full path+filename to launch TurboGrid when --execution-mode==DIRECT",
+    )
+    parser.addoption(
+        "--log_level",
+        action="store",
+        default="INFO",
+        help="Sets the log level for the python client",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "NETWORK_DEBUG", "DEBUG"),
+    )
+
+
+def get_additional_args(debug_env: str) -> str:
+    is_debug = os.getenv(debug_env)
+    if is_debug == "1":
+        additional_args = "-debug"
+    else:
+        additional_args = None
+    return additional_args
+
+
+def get_path_to_engine(
+    app_versions: list,
+    relative_path: str,
+    app_name: str,
+) -> str:
+    path_to_engine: str = ""
+    for version in app_versions:
+        awp_root = os.environ.get("AWP_ROOT" + version)
+        if awp_root:
+            path_to_engine = os.path.join(awp_root, relative_path)
+            break
+    if not path_to_engine:
+        raise RuntimeError(f"Path to {app_name} could not be determined")
+    return path_to_engine
+
+
+def get_additional_kw_args(local_root_env: str) -> Optional[dict]:
+    local_root = os.getenv(local_root_env)
+    if local_root:
+        additional_kw_args = {"local-root": local_root}
+    else:
+        additional_kw_args = None
+    return additional_kw_args
+
+
+def get_str_value_from_env(env_var_name: str, default_value: str, required: bool = False) -> str:
+    value = os.getenv(env_var_name)
+    if not value:
+        if required:
+            print(os.environ)
+            raise Exception(f"{env_var_name} must be defined in the environment.")
+        else:
+            value = default_value
+    return value
+
+
+def get_int_value_from_env(env_var_name: str, default_value: str, required: bool = False) -> int:
+    str_val: str = get_str_value_from_env(env_var_name, default_value, required)
+    int_val: int = int(str_val)
+    return int_val
+
+
+def get_enum_value_from_env(
+    env_var_name: str, enum_type, default_value, valid_values_str: str, required: bool = False
+):
+    enum_value = get_str_value_from_env(env_var_name, default_value.name, required)
+    try:
+        enum_value = enum_type[enum_value]
+    except KeyError:
+        raise RuntimeError(
+            f"Environment variable {env_var_name} was set to an invalid value '{enum_value}'. Valid values include {valid_values_str}."
+        )
+    return enum_value
+
+
+def get_tg_container(pytestconfig, socket_port: int) -> deployed_tg_container:
+    container_name: str = pytestconfig.getoption("container_name")
+    # Generate a random integer with 10 digits
+    random_number = random.randint(10**9, 10**10 - 1)
+    container_name = container_name + str(random_number)
+    image_name: str = pytestconfig.getoption("image_name")
+    # The path to cfxtg_command is standardized by the container, so just replace the command name.
+    # This allows image developers to write custom cfxtg commands.
+    cfxtg_command: str = pytestconfig.getoption("cfxtg_command_name")
+    cfxtg_command = f"./v{pytestconfig.getoption('cfx_version')}/TurboGrid/bin/{cfxtg_command} -py -control-port {socket_port}"
+
+    license_server: str = pytestconfig.getoption("license_file")
+    pytest.ftp_port = get_open_port()
+
+    tg_instance = deployed_tg_container(
+        image_name,
+        socket_port,
+        pytest.ftp_port,
+        cfxtg_command,
+        license_server,
+        container_name,
+        pytestconfig.getoption("keep_stopped_containers"),
+        ast.literal_eval(pytestconfig.getoption("container_env_dict")),
+    )
+    return tg_instance
+
+
+def get_open_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # using '0' will tell the OS to pick a random port that is available.
+        s.bind(("", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        # Shutdown is not needed because the socket is not connected.
+        # Also, this will throw and error in windows
+        # s.shutdown(socket.SHUT_RDWR)
+        s.close()
+    # Wait a second to let the OS do things
+    time.sleep(1)
+    return port
+
+
+class Helpers:
+    pytestconfig: None
+
+    def __init__(self, pytcfg):
+        self.pytestconfig = pytcfg
+
+    def get_container_connection(self, ftp_port: int, host_name="localhost"):
+        container_connection = Connection(
+            host=host_name,
+            user="root",
+            port=ftp_port,
+            connect_kwargs={"key_filename": self.pytestconfig.getoption("ssh_key_filename")},
+        )
+        return container_connection
+
+    @staticmethod
+    def transfer_file_to_container(container_connection: Connection, local_filepath: str):
+        print(f"To container-> {local_filepath}")
+        container_connection.put(
+            remote="/",
+            local=local_filepath,
+        )
+
+    @staticmethod
+    def transfer_files_to_container(
+        container_connection: Connection, local_folder_path: str, local_filenames: list
+    ):
+        for filename in local_filenames:
+            Helpers.transfer_file_to_container(
+                container_connection, f"{local_folder_path}/{filename}"
+            )
+
+    @staticmethod
+    def transfer_file_from_container(
+        container_connection: Connection, remote_filename: str, local_path_only: str
+    ):
+        print(f"From container-> {local_path_only}/{remote_filename}")
+        container_connection.get(
+            remote=f"/{remote_filename}",
+            local=f"{local_path_only}/{remote_filename}",
+        )
+
+    @staticmethod
+    def transfer_files_from_container(
+        container_connection: Connection, local_folder_path: str, remote_filenames: list
+    ):
+        for filename in remote_filenames:
+            Helpers.transfer_file_from_container(container_connection, filename, local_folder_path)
+
+
+@pytest.fixture
+def helpers(pytestconfig):
+    return Helpers(pytestconfig)
 
 
 # Fixtures are set-up methods. The method is passed as an argument to the test method and will be
 # run before the method definition.
 @pytest.fixture
-def pyturbogrid() -> pyturbogrid_core.PyTurboGrid:
-    pytest.socket_port += 1
-    is_debug = os.getenv("PYTURBOGRID_DEBUG")
-    if is_debug == "1":
-        additional_args = "-debug"
-    else:
-        additional_args = None
+def pyturbogrid(pytestconfig, request) -> pyturbogrid_core.PyTurboGrid:
+    pytest.socket_port = get_open_port()
 
-    tg_local_root = os.getenv("PYTURBOGRID_TURBOGRID_LOCAL_ROOT")
-    if tg_local_root:
-        additional_kw_args = {"local-root": tg_local_root}
-    else:
-        additional_kw_args = None
+    turbogrid_versions = ["241", "232"]
 
-    pyturbogrid = launch_turbogrid(
-        additional_args_str=additional_args,
-        additional_kw_args=additional_kw_args,
-        port=pytest.socket_port,
+    pytest.turbogrid_log_level = pyturbogrid_core.PyTurboGrid.TurboGridLogLevel[
+        pytestconfig.getoption("log_level")
+    ]
+    pytest.execution_mode = TestExecutionMode[pytestconfig.getoption("execution_mode")]
+    # Regardless of this parameter, if we specified CONTAINERIZED above,
+    # set this to the remote option
+
+    pytest.turbogrid_install_type = (
+        get_enum_value_from_env(
+            "PYTURBOGRID_LOCATION_TYPE",
+            pyturbogrid_core.PyTurboGrid.TurboGridLocationType,
+            pyturbogrid_core.PyTurboGrid.TurboGridLocationType.TURBOGRID_INSTALL,
+            "'TURBOGRID_INSTALL' and 'TURBOGRID_RUNNING_CONTAINER'",
+        )
+        if pytest.execution_mode == TestExecutionMode.DIRECT
+        else pyturbogrid_core.PyTurboGrid.TurboGridLocationType.TURBOGRID_RUNNING_CONTAINER
     )
-    print("Success")
-    return pyturbogrid
+
+    if pytest.execution_mode != TestExecutionMode.REMOTE:
+        print(f"Creating fixture on port {pytest.socket_port}")
+
+    tg_execution_control: deployed_tg_container | remote_tg_instance | None = None
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        tg_execution_control = get_tg_container(pytestconfig, pytest.socket_port)
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        tg_execution_control = remote_tg_instance(
+            pytest.socket_port,
+            pytestconfig.getoption("remote_command"),
+        )
+
+    # path_to_cfxtg = (
+    #     get_path_to_engine(turbogrid_versions, "TurboGrid/bin/cfxtg", "cfxtg")
+    #     if pytest.execution_mode == TestExecutionMode.DIRECT
+    #     else ""
+    # )
+
+    pytest.path_to_cfxtg = (
+        pytestconfig.getoption("local_cfxtg_path")
+        if pytest.execution_mode == TestExecutionMode.DIRECT
+        else ""
+    )
+
+    pytest.additional_args = get_additional_args(debug_env="PYTURBOGRID_DEBUG")
+    pytest.additional_kw_args = get_additional_kw_args(
+        local_root_env="PYTURBOGRID_TURBOGRID_LOCAL_ROOT"
+    )
+
+    pyturbogrid = pyturbogrid_core.PyTurboGrid(
+        socket_port=pytest.socket_port,
+        turbogrid_location_type=pytest.turbogrid_install_type,
+        cfxtg_location=pytest.path_to_cfxtg,
+        log_level=pytest.turbogrid_log_level,
+        additional_args_str=pytest.additional_args,
+        additional_kw_args=pytest.additional_kw_args,
+        log_filename_suffix=request.node.name,
+    )
+
+    # pyturbogrid = launch_turbogrid(
+    #     additional_args_str=additional_args,
+    #     additional_kw_args=additional_kw_args,
+    #     port=pytest.socket_port,
+    # )
+
+    yield pyturbogrid
+    # Because of conf-testy things, we can't rely on the proper lifetime management here
+    pyturbogrid.quit()
+    if tg_execution_control:
+        del tg_execution_control

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,11 @@ else:
 
 # For now, this relies on the installed package because of github reasons.
 # If you want to use a 'local' api module, you can use the following:
-pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
-if pyturbogrid_api_root:
-    sys.path.append(f"{pyturbogrid_api_root}/src")
-else:
-    raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
+# pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
+# if pyturbogrid_api_root:
+#     sys.path.append(f"{pyturbogrid_api_root}/src")
+# else:
+#     raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
 
 from ansys.turbogrid.api import pyturbogrid_core
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,11 @@ else:
 
 # For now, this relies on the installed package because of github reasons.
 # If you want to use a 'local' api module, you can use the following:
-# pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
-# if pyturbogrid_api_root:
-#     sys.path.append(f"{pyturbogrid_api_root}/src")
-# else:
-#     raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
+pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
+if pyturbogrid_api_root:
+    sys.path.append(f"{pyturbogrid_api_root}/src")
+else:
+    raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
 
 from ansys.turbogrid.api import pyturbogrid_core
 
@@ -78,22 +78,28 @@ def pytest_addoption(parser):
     parser.addoption(
         "--ssh_key_filename",
         action="store",
-        help="The location of the ssh key for connection to the TurboGrid container. "
-        "Used when --execution-mode==CONTAINERIZED",
+        help=(
+            "The location of the ssh key for connection to the TurboGrid container. "
+            "Used when --execution-mode==CONTAINERIZED"
+        ),
     )
     parser.addoption(
         "--container_env_dict",
         action="store",
         default="{}",
-        help="A dictionary for additional environment variables to pass to the container. "
-        "Used when --execution-mode==CONTAINERIZED",
+        help=(
+            "A dictionary for additional environment variables to pass to the container. "
+            "Used when --execution-mode==CONTAINERIZED"
+        ),
     )
     parser.addoption(
         "--keep_stopped_containers",
         action="store_true",
         default=False,
-        help="Whether or not to leave the stopped containers around without removing them. "
-        "Used when --execution-mode==CONTAINERIZED",
+        help=(
+            "Whether or not to leave the stopped containers around without removing them. "
+            "Used when --execution-mode==CONTAINERIZED"
+        ),
     )
     parser.addoption(
         "--remote_command",
@@ -188,8 +194,10 @@ def get_tg_container(pytestconfig, socket_port: int) -> deployed_tg_container:
     # The path to cfxtg_command is standardized by the container, so just replace the command name.
     # This allows image developers to write custom cfxtg commands.
     cfxtg_command: str = pytestconfig.getoption("cfxtg_command_name")
-    cfxtg_command = f"./v{pytestconfig.getoption('cfx_version')}/TurboGrid/bin/{cfxtg_command} "
-    f"-py -control-port {socket_port}"
+    cfxtg_command = (
+        f"./v{pytestconfig.getoption('cfx_version')}/TurboGrid/bin/{cfxtg_command} "
+        f"-py -control-port {socket_port}"
+    )
 
     license_server: str = pytestconfig.getoption("license_file")
     pytest.ftp_port = get_open_port()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,13 @@ if pyturbogrid_root:
 else:
     sys.path.append("./src")
 
-pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
-if pyturbogrid_api_root:
-    sys.path.append(f"{pyturbogrid_api_root}/src")
-else:
-    raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
+# For now, this relies on the installed package because of github reasons.
+# If you want to use a 'local' api module, you can use the following:
+# pyturbogrid_api_root = os.getenv("PYTURBOGRID_API_ROOT")
+# if pyturbogrid_api_root:
+#     sys.path.append(f"{pyturbogrid_api_root}/src")
+# else:
+#     raise RuntimeError("PYTURBOGRID_API_ROOT must be defined")
 
 from ansys.turbogrid.api import pyturbogrid_core
 

--- a/tests/test_mesh_statistics.py
+++ b/tests/test_mesh_statistics.py
@@ -6,12 +6,33 @@ import os
 from pathlib import Path
 
 from ansys.turbogrid.api import pyturbogrid_core
+import pytest
 
 from ansys.turbogrid.core.mesh_statistics import mesh_statistics
+from conftest import Helpers, TestExecutionMode
+
+dir_path: str = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_get_mesh_statistics_basic(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_get_mesh_statistics_basic(pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid)
@@ -28,8 +49,27 @@ def test_get_mesh_statistics_basic(pyturbogrid: pyturbogrid_core.PyTurboGrid):
     assert single_var["Limits Type"] == "Minimum"
 
 
-def test_get_mesh_statistics_with_domain(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_get_mesh_statistics_with_domain(
+    pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers
+):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid)
@@ -57,8 +97,25 @@ def test_get_mesh_statistics_with_domain(pyturbogrid: pyturbogrid_core.PyTurboGr
     assert all_dom_count == passage_dom_count + inlet_dom_count + outlet_dom_count
 
 
-def test_update_mesh_statistics(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_update_mesh_statistics(pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid)
@@ -75,8 +132,25 @@ def test_update_mesh_statistics(pyturbogrid: pyturbogrid_core.PyTurboGrid):
     assert new_elem_count > old_elem_count
 
 
-def test_create_histogram(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_create_histogram(pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid)
@@ -101,8 +175,25 @@ def test_create_histogram(pyturbogrid: pyturbogrid_core.PyTurboGrid):
         os.remove(image_file)
 
 
-def test_write_table_to_csv(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_write_table_to_csv(pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid)
@@ -125,8 +216,25 @@ def test_write_table_to_csv(pyturbogrid: pyturbogrid_core.PyTurboGrid):
         os.remove(csv_file)
 
 
-def test_get_table_as_text(pyturbogrid: pyturbogrid_core.PyTurboGrid):
-    pyturbogrid.read_state(filename="tests/rotor37/Rotor37State.tst")
+def test_get_table_as_text(pyturbogrid: pyturbogrid_core.PyTurboGrid, helpers: Helpers):
+    if pytest.execution_mode == TestExecutionMode.REMOTE:
+        pyturbogrid.block_each_message = True
+
+    if pytest.execution_mode == TestExecutionMode.CONTAINERIZED:
+        pyturbogrid.block_each_message = True
+        container = helpers.get_container_connection(pytest.ftp_port)
+        print(f"transfer files to container {dir_path}")
+        helpers.transfer_files_to_container(
+            container,
+            f"{dir_path}/rotor37/",
+            ["Rotor37State.tst", "BladeGen.inf", "hub.curve", "shroud.curve", "profile.curve"],
+        )
+        print(f"files transferred")
+
+    tg_file_path: str = (
+        f"{dir_path}/rotor37/" if pytest.execution_mode != TestExecutionMode.CONTAINERIZED else "/"
+    )
+    pyturbogrid.read_state(filename=f"{tg_file_path}/Rotor37State.tst")
     pyturbogrid.unsuspend(object="/TOPOLOGY SET")
 
     ms = mesh_statistics.MeshStatistics(pyturbogrid, "Inlet")


### PR DESCRIPTION
Note that Github does not support unit tests with windows containers, or running linux images with a windows runner.

Lots of code was ported over from the API repo. It is duplicated, although it's likely the conftest files will need to diverge, which is not an issue.

The ssh key is stored as a secret under CONTAINER_ACCESS_KEY. It is encoded as base64 and an action manages the file creation/deletion.
