### PR TITLE
Support autodoc for gh workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,12 @@ jobs:
       - name: Save Docker image to a file
         run: docker save -o image.tar ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:242  
   
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Cache Docker image file
+        uses: actions/cache@v2
         with:
-          name: image
           path: image.tar
+          key: myimage-${{ github.sha }}
+          restore-keys: myimage-
 
   docs-build:
     name: "Build documentation"
@@ -83,11 +84,12 @@ jobs:
       PYTURBOGRID_DOC_VERSION: 242
       PYTURBOGRID_DOC_ENGINE_CONNECTION: 6000    
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
+      - name: Restore Cached Docker image file
+        uses: actions/cache@v2
         with:
-          name: image
           path: image.tar
+          key: myimage-${{ github.sha }}
+          restore-keys: myimage-
 
       - name: Load Docker image from file
         run: docker load -i image.tar
@@ -129,11 +131,12 @@ jobs:
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}        
 
-      - name: Download artifact
-        uses: actions/download-artifact@v2
+      - name: Restore Cached Docker image file
+        uses: actions/cache@v2
         with:
-          name: image
           path: image.tar
+          key: myimage-${{ github.sha }}
+          restore-keys: myimage-
 
       - name: Load Docker image from file
         run: docker load -i image.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
   prereqs:
     name: "Pre-requisites for docs and tests"          
     runs-on: ubuntu-latest
+    needs: [code-style, docs-style]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
           docker network ls
           docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:242    
 
+      - name: Save Docker image to a file
+        run: docker save -o image.tar ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:242  
+  
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: image
+          path: image.tar
+
   docs-build:
     name: "Build documentation"
     runs-on: ubuntu-latest
@@ -74,6 +83,15 @@ jobs:
       PYTURBOGRID_DOC_VERSION: 242
       PYTURBOGRID_DOC_ENGINE_CONNECTION: 6000    
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: image
+          path: image.tar
+
+      - name: Load Docker image from file
+        run: docker load -i image.tar
+
       - uses: ansys/actions/doc-build@v5
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
@@ -110,6 +128,15 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}        
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: image
+          path: image.tar
+
+      - name: Load Docker image from file
+        run: docker load -i image.tar
 
       - name: Create Key
         uses: mobiledevops/secret-to-file-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     needs: [prereqs]
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
-      PYTURBOGRID_DOC_VERSION: 241
+      PYTURBOGRID_DOC_VERSION: 242
       PYTURBOGRID_DOC_ENGINE_CONNECTION: 6000    
     steps:
       - uses: ansys/actions/doc-build@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,30 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}  
   
- 
+  prereqs:
+    name: "Pre-requisites for docs and tests"          
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull TurboGrid Linux Image
+        run: |
+          docker network ls
+          docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:242    
+
   docs-build:
     name: "Build documentation"
     runs-on: ubuntu-latest
-    needs: [docs-style]
+    needs: [prereqs]
+    env:
+      ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
+      PYTURBOGRID_DOC_VERSION: 241
+      PYTURBOGRID_DOC_ENGINE_CONNECTION: 6000    
     steps:
       - uses: ansys/actions/doc-build@v5
         with:
@@ -78,7 +97,7 @@ jobs:
   smoke-tests:
     name: "Build wheelhouse and Test for ${{ matrix.os }} and Python ${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
-    needs: [code-style]
+    needs: [prereqs]
     strategy:
       fail-fast: false
       matrix:
@@ -90,17 +109,6 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}        
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull TurboGrid Linux Image
-        run: |
-          docker network ls
-          docker pull ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:242    
 
       - name: Create Key
         uses: mobiledevops/secret-to-file-action@v1
@@ -119,7 +127,7 @@ jobs:
             exit 1
           fi
           
-      - name: Spin Up TurboGrid Container
+      - name: Run Unit Tests
         run: |
           docker image ls
           pip install pytest

--- a/src/ansys/turbogrid/core/__init__.py
+++ b/src/ansys/turbogrid/core/__init__.py
@@ -31,6 +31,7 @@ socket_port = os.getenv("PYTURBOGRID_DOC_ENGINE_CONNECTION")
 tg_container = None
 if socket_port is not None:
     import atexit
+
     from ansys.turbogrid.core.launcher.deploy_tg_container import deployed_tg_container
 
     print("Running init for ansys turbogrid core")

--- a/src/ansys/turbogrid/core/__init__.py
+++ b/src/ansys/turbogrid/core/__init__.py
@@ -23,6 +23,28 @@
 
 """PyTurboGrid is a Python wrapper for Ansys TurboGrid."""
 
+import os
+
+# When this is defined, hardcode a tg container spinup for the purpose of auto documentation.
+# Intended only for github CI runs.
+socket_port = os.getenv("PYTURBOGRID_DOC_ENGINE_CONNECTION")
+tg_container = None
+if socket_port is not None:
+    import atexit
+    from ansys.turbogrid.core.launcher.deploy_tg_container import deployed_tg_container
+
+    print("Running init for ansys turbogrid core")
+    socket_port = int(socket_port)
+    tg_version = os.environ.get("PYTURBOGRID_DOC_VERSION")
+    cfxtg_command = f"./v{tg_version}/TurboGrid/bin/cfxtgpynoviewer -py -control-port {socket_port}"
+    image_name = f"ghcr.io/ansys/ansys-api-turbogrid/tglin_reduced_ndf:{tg_version}"
+    container_name = "TG_DOCBUILD_CONTAINER"
+    license_server = os.environ.get("ANSYSLMD_LICENSE_FILE")
+    tg_container = deployed_tg_container(
+        image_name, socket_port, socket_port + 1, cfxtg_command, license_server, container_name
+    )
+    atexit.register(tg_container.__del__)
+
 from ansys.turbogrid.core.launcher.launcher import launch_turbogrid
 
 try:


### PR DESCRIPTION
1. Container pull is moved to be a pre-req for both doc and smoke tests.
2. With the correct env var set, the sphinx doc mechanism will trigger the __init__.py file, which triggers the container launch.
3. doc monkey patching is already written in tg-api.
4. using atexit, the container is shut down, so that multiple launches are supported.