### PR TITLE
multi_blade_row_batch changes for writing tginit from ndf differently in local and container modes

### DIFF
--- a/examples/multi_blade_row_batch_example.py
+++ b/examples/multi_blade_row_batch_example.py
@@ -69,7 +69,6 @@ if __name__ == "__main__":
     mbr_instance.set_spanwise_counts(56, 73)
     mbr_instance.set_global_size_factor(1.5)
     mbr_instance.set_blade_boundary_layer_offsets(6e-6)
-    mbr_instance.write_tginit_first = True
 
     # Call the execute method to perform the meshing.
     mbr_instance.execute()


### PR DESCRIPTION
In a local machine TurboGrid mode for multi-blade-row batch process, tginit should be written first and then the TurboGrid runners should load the tginit instead of provided ndf file.
In Ansys Labs TurboGrid mode, each TurboGrid should read ndf itself separately and create its own tginit and parasolid files.
