### PR TITLE
set InitStyle.TGInit for read_tginit_into_blank

### DIFF
--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -334,6 +334,9 @@ class multi_blade_row:
             ]
             concurrent.futures.wait(futures)
 
+        self.init_style = InitStyle.TGInit
+        self.tginit_path = tginit_path
+
     def init_from_tginit(
         self,
         tginit_path: str,


### PR DESCRIPTION
This setting was missed, and is needed for saving state