### PR TITLE
chore: auto merge dependabot PR for s1444990

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -50,7 +50,7 @@ jobs:
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.PYANSYS_CI_BOT_TOKEN }}"
       - name: Dependabot debug printouts
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         run: |

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'ansys-internal-release-please[bot]'
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       ACTOR: ${{ github.event.pull_request.user.login }}
     steps:
@@ -63,13 +63,12 @@ jobs:
           DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
-          if [ "$ACTOR" == "pyansys-ci-bot" ]; then
-            echo "Actor is the pyansys-ci-bot (used to release-please on Ansys org repos)"
-          else
-            echo "Actor is Dependabot"
-          fi
           review_requests=$(gh pr view "$PR_NUMBER" --json reviewRequests --jq '.reviewRequests[].login')
           echo "Approving PR and enabling auto-merge as review was requested."
           gh pr review --approve "$PR_URL"
-        # gh pr merge --auto --squash "$PR_URL"
+          if [ "$ACTOR" == "dependabot[bot]" ]; then
+            echo "Actor is Dependabot, auto merging..."
+            gh pr merge --auto --squash "$PR_URL"
+          fi
+
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a different authentication token for Dependabot automation. The change improves security and control over workflow permissions.

**CI/CD and Automation:**

* Updated the `github-token` used by the `dependabot/fetch-metadata` action from the default `GITHUB_TOKEN` to a custom `PYANSYS_CI_BOT_TOKEN` in `.github/workflows/automation.yml`.