### PR TITLE
chore: CODEOWNERS update for s1444990

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @acohen-work @zlilek-work
+*       @acohen-work @zlilek-work @pyansys-ci-bot


### PR DESCRIPTION
This pull request makes a small update to the `CODEOWNERS` file by adding `@pyansys-ci-bot` as a default code owner for the repository.