### PR TITLE
feat: get_turbo_coordinates_boundary_points in multi_blade_row

### DIFF
--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -914,7 +914,7 @@ class multi_blade_row:
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
 
-    def get_turbo_coordinates_BM_boundary_curves(self) -> dict[str, any]:
+    def get_turbo_coordinates_boundary_geometry_points(self) -> dict[str, any]:
         """
         Get the Turbo Transform boundary curves in a dictionary format for each blade row.
 
@@ -923,13 +923,13 @@ class multi_blade_row:
             max_workers=len(self.tg_worker_instances)
         ) as executor:
             futures = [
-                executor.submit(self.__get_turbo_coordinates_BM_boundary_curves__, key, val)
+                executor.submit(self.__get_turbo_coordinates_boundary_geometry_points__, key, val)
                 for key, val in self.tg_worker_instances.items()
             ]
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
 
-    def get_turbo_coordinates_BM_boundary_points(self) -> dict[str, any]:
+    def get_turbo_coordinates_boundary_BM_points(self) -> dict[str, any]:
         """
         Get the Turbo Transform boundary points in a dictionary format for each blade row.
 
@@ -938,7 +938,7 @@ class multi_blade_row:
             max_workers=len(self.tg_worker_instances)
         ) as executor:
             futures = [
-                executor.submit(self.__get_turbo_coordinates_BM_boundary_points__, key, val)
+                executor.submit(self.__get_turbo_coordinates_boundary_BM_points__, key, val)
                 for key, val in self.tg_worker_instances.items()
             ]
             done, not_done = concurrent.futures.wait(futures)
@@ -1649,7 +1649,7 @@ class multi_blade_row:
             pass
         return (tg_worker_name, turbo_data)
 
-    def __get_turbo_coordinates_BM_boundary_curves__(
+    def __get_turbo_coordinates_boundary_geometry_points__(
         self, tg_worker_name, tg_worker_instance
     ) -> tuple[str, dict[str, any]]:
         """
@@ -1657,15 +1657,17 @@ class multi_blade_row:
         """
         boundary_curves_data = {}
         try:
-            boundary_curves_data = tg_worker_instance.pytg.getTurboCoordinatesBMBoundaryCurves()
+            boundary_curves_data = (
+                tg_worker_instance.pytg.getTurboCoordinatesBoundaryGeometryPoints()
+            )
         except Exception as e:
             print(
-                f"{tg_worker_instance} exception on __get_turbo_coordinates_BM_boundary_curves__: {e}"
+                f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_geometry_points__: {e}"
             )
             pass
         return (tg_worker_name, boundary_curves_data)
 
-    def __get_turbo_coordinates_BM_boundary_points__(
+    def __get_turbo_coordinates_boundary_BM_points__(
         self, tg_worker_name, tg_worker_instance
     ) -> tuple[str, dict[str, any]]:
         """
@@ -1673,10 +1675,10 @@ class multi_blade_row:
         """
         boundary_points_data = {}
         try:
-            boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBMBoundaryPoints()
+            boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBoundaryBMPoints()
         except Exception as e:
             print(
-                f"{tg_worker_instance} exception on __get_turbo_coordinates_BM_boundary_points__: {e}"
+                f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_BM_points__: {e}"
             )
             pass
         return (tg_worker_name, boundary_points_data)

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -928,7 +928,7 @@ class multi_blade_row:
             ]
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
-        
+
     def get_turbo_coordinates_BM_boundary_points(self) -> dict[str, any]:
         """
         Get the Turbo Transform boundary points in a dictionary format for each blade row.
@@ -1648,7 +1648,7 @@ class multi_blade_row:
             print(f"{tg_worker_instance} exception on __get_turbo_domain_assembly__")
             pass
         return (tg_worker_name, turbo_data)
-    
+
     def __get_turbo_coordinates_BM_boundary_curves__(
         self, tg_worker_name, tg_worker_instance
     ) -> tuple[str, dict[str, any]]:
@@ -1664,7 +1664,7 @@ class multi_blade_row:
             )
             pass
         return (tg_worker_name, boundary_curves_data)
-    
+
     def __get_turbo_coordinates_BM_boundary_points__(
         self, tg_worker_name, tg_worker_instance
     ) -> tuple[str, dict[str, any]]:

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -914,7 +914,7 @@ class multi_blade_row:
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
 
-    def get_turbo_coordinate_boundary_points(self) -> dict[str, any]:
+    def get_turbo_coordinates_boundary_points(self) -> dict[str, any]:
         """
         Get the mesh boundary points in a dictionary format for each blade row.
 
@@ -923,7 +923,7 @@ class multi_blade_row:
             max_workers=len(self.tg_worker_instances)
         ) as executor:
             futures = [
-                executor.submit(self.__get_turbo_coordinate_boundary_points__, key, val)
+                executor.submit(self.__get_turbo_coordinates_boundary_points__, key, val)
                 for key, val in self.tg_worker_instances.items()
             ]
             done, not_done = concurrent.futures.wait(futures)

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -1643,8 +1643,8 @@ class multi_blade_row:
         boundary_points_data = {}
         try:
             boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBoundaryPoints()
-        except:
-            print(f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__")
+        except Exception as e:
+            print(f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__: {e}")
             pass
         return (tg_worker_name, boundary_points_data)
 

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -1644,7 +1644,9 @@ class multi_blade_row:
         try:
             boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBoundaryPoints()
         except Exception as e:
-            print(f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__: {e}")
+            print(
+                f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__: {e}"
+            )
             pass
         return (tg_worker_name, boundary_points_data)
 

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -914,16 +914,31 @@ class multi_blade_row:
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
 
-    def get_turbo_coordinates_boundary_points(self) -> dict[str, any]:
+    def get_turbo_coordinates_BM_boundary_curves(self) -> dict[str, any]:
         """
-        Get the mesh boundary points in a dictionary format for each blade row.
+        Get the Turbo Transform boundary curves in a dictionary format for each blade row.
 
         """
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(self.tg_worker_instances)
         ) as executor:
             futures = [
-                executor.submit(self.__get_turbo_coordinates_boundary_points__, key, val)
+                executor.submit(self.__get_turbo_coordinates_BM_boundary_curves__, key, val)
+                for key, val in self.tg_worker_instances.items()
+            ]
+            done, not_done = concurrent.futures.wait(futures)
+            return {f.result()[0]: f.result()[1] for f in done}
+        
+    def get_turbo_coordinates_BM_boundary_points(self) -> dict[str, any]:
+        """
+        Get the Turbo Transform boundary points in a dictionary format for each blade row.
+
+        """
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=len(self.tg_worker_instances)
+        ) as executor:
+            futures = [
+                executor.submit(self.__get_turbo_coordinates_BM_boundary_points__, key, val)
                 for key, val in self.tg_worker_instances.items()
             ]
             done, not_done = concurrent.futures.wait(futures)
@@ -1633,8 +1648,24 @@ class multi_blade_row:
             print(f"{tg_worker_instance} exception on __get_turbo_domain_assembly__")
             pass
         return (tg_worker_name, turbo_data)
-
-    def __get_turbo_coordinates_boundary_points__(
+    
+    def __get_turbo_coordinates_BM_boundary_curves__(
+        self, tg_worker_name, tg_worker_instance
+    ) -> tuple[str, dict[str, any]]:
+        """
+        :meta private:
+        """
+        boundary_curves_data = {}
+        try:
+            boundary_curves_data = tg_worker_instance.pytg.getTurboCoordinatesBMBoundaryCurves()
+        except Exception as e:
+            print(
+                f"{tg_worker_instance} exception on __get_turbo_coordinates_BM_boundary_curves__: {e}"
+            )
+            pass
+        return (tg_worker_name, boundary_curves_data)
+    
+    def __get_turbo_coordinates_BM_boundary_points__(
         self, tg_worker_name, tg_worker_instance
     ) -> tuple[str, dict[str, any]]:
         """
@@ -1642,10 +1673,10 @@ class multi_blade_row:
         """
         boundary_points_data = {}
         try:
-            boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBoundaryPoints()
+            boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBMBoundaryPoints()
         except Exception as e:
             print(
-                f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__: {e}"
+                f"{tg_worker_instance} exception on __get_turbo_coordinates_BM_boundary_points__: {e}"
             )
             pass
         return (tg_worker_name, boundary_points_data)

--- a/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
+++ b/src/ansys/turbogrid/core/multi_blade_row/multi_blade_row.py
@@ -914,6 +914,21 @@ class multi_blade_row:
             done, not_done = concurrent.futures.wait(futures)
             return {f.result()[0]: f.result()[1] for f in done}
 
+    def get_turbo_coordinate_boundary_points(self) -> dict[str, any]:
+        """
+        Get the mesh boundary points in a dictionary format for each blade row.
+
+        """
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=len(self.tg_worker_instances)
+        ) as executor:
+            futures = [
+                executor.submit(self.__get_turbo_coordinate_boundary_points__, key, val)
+                for key, val in self.tg_worker_instances.items()
+            ]
+            done, not_done = concurrent.futures.wait(futures)
+            return {f.result()[0]: f.result()[1] for f in done}
+
     def get_mesh_statistics_reporters(self) -> dict[str, any]:
         from ansys.turbogrid.core.mesh_statistics import mesh_statistics
 
@@ -1618,6 +1633,20 @@ class multi_blade_row:
             print(f"{tg_worker_instance} exception on __get_turbo_domain_assembly__")
             pass
         return (tg_worker_name, turbo_data)
+
+    def __get_turbo_coordinates_boundary_points__(
+        self, tg_worker_name, tg_worker_instance
+    ) -> tuple[str, dict[str, any]]:
+        """
+        :meta private:
+        """
+        boundary_points_data = {}
+        try:
+            boundary_points_data = tg_worker_instance.pytg.getTurboCoordinatesBoundaryPoints()
+        except:
+            print(f"{tg_worker_instance} exception on __get_turbo_coordinates_boundary_points__")
+            pass
+        return (tg_worker_name, boundary_points_data)
 
     def __save_mesh__(
         self, tg_worker_name, tg_worker_instance, optional_prefix: str = None, file_format="def"


### PR DESCRIPTION
This pull request adds new functionality to retrieve Turbo Transform boundary geometry and boundary BM points for each blade row in a multi-blade row context. The new methods use concurrent execution to efficiently gather data from all blade rows and include error handling for robustness.

**New methods for boundary data retrieval:**

* Added `get_turbo_coordinates_boundary_geometry_points` and `get_turbo_coordinates_boundary_BM_points` methods to retrieve Turbo Transform boundary geometry and BM points for each blade row concurrently.
* Implemented corresponding private helper methods `__get_turbo_coordinates_boundary_geometry_points__` and `__get_turbo_coordinates_boundary_BM_points__` that interact with the underlying `pytg` API, including exception handling for each worker instance.